### PR TITLE
Change how stress tests clone the testing repo

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,8 +2,16 @@ name: pytest
 
 on:
   push:
+    branches: [ main ]
   pull_request:
-  workflow_dispatch:
+    branches: [ main ]
+  # Allow rebuilds via API.
+  repository_dispatch:
+    types: rebuild
+
+concurrency:
+  group: run_tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -17,6 +25,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: MontrealCorpusTools/PolyglotDB
+        fetch-depth: 0
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v4

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -25,7 +25,6 @@ jobs:
         repository: MontrealCorpusTools/polyglotdb-testing
         ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
         path: ${{ github.workspace }}/testing
-        fetch-depth: 0
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v4

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -17,16 +17,12 @@ jobs:
       with:
         repository: MontrealCorpusTools/PolyglotDB
 
-    - name: Set up Git for cloning
-      run: |
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
-
-    - name: Clone the private repository
-      run: |
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{ secrets.TESTING_SSH_KEY }}'
-        git clone ssh://git@github.com/MontrealCorpusTools/polyglotdb-testing.git testing
+    - name: Checkout testing repository
+      uses: actions/checkout@v3
+      with:
+        repository: MontrealCorpusTools/polyglotdb-testing
+        ssh-key: ${{ secrets.TESTING_SSH_KEY }}
+        path: testing
 
     - name: Set environment variable for private repo root
       run: echo "TEST_REPO_ROOT=$(pwd)/testing" >> $GITHUB_ENV

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -27,7 +27,10 @@ jobs:
         fetch-depth: 0
 
     - name: Set environment variable for private repo root
-      run: echo "TEST_REPO_ROOT=$(pwd)/testing" >> $GITHUB_ENV
+      run: |
+        echo "TEST_REPO_ROOT=$(pwd)/testing" >> $GITHUB_ENV
+        ls
+        ls $TEST_REPO_ROOT
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v4
@@ -44,7 +47,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libsndfile1
-
 
     - name: Install required packages
       run: |

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -13,16 +13,18 @@ jobs:
 
     steps:
     - name: Checkout main repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@main
       with:
         repository: MontrealCorpusTools/PolyglotDB
+        fetch-depth: 0
 
     - name: Checkout testing repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@main
       with:
         repository: MontrealCorpusTools/polyglotdb-testing
         ssh-key: ${{ secrets.TESTING_SSH_KEY }}
         path: testing
+        fetch-depth: 0
 
     - name: Set environment variable for private repo root
       run: echo "TEST_REPO_ROOT=$(pwd)/testing" >> $GITHUB_ENV

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -25,6 +25,7 @@ jobs:
         repository: MontrealCorpusTools/polyglotdb-testing
         ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
         path: ${{ github.workspace }}/testing
+        lfs: true
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v4
@@ -40,7 +41,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libsndfile1 sox
+        sudo apt-get install -y libsndfile1
 
     - name: Install required packages
       run: |
@@ -60,10 +61,6 @@ jobs:
 
     - name: Run duration.py
       run: |
-        echo $TEST_REPO_ROOT
-        ls $TEST_REPO_ROOT
-        ls -al $TEST_REPO_ROOT/ice-can/audio_and_transcripts
-        soxi $TEST_REPO_ROOT/ice-can/audio_and_transcripts/S2A-001_1.wav
         source venv/bin/activate
         cd testing
         python duration.py -r ice-can

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libsndfile1
+        sudo apt-get install -y libsndfile1 sox
 
     - name: Install required packages
       run: |
@@ -63,6 +63,8 @@ jobs:
       run: |
         echo $TEST_REPO_ROOT
         ls $TEST_REPO_ROOT
+        ls -al $TEST_REPO_ROOT/ice-can/audio_and_transcripts
+        soxi $TEST_REPO_ROOT/ice-can/audio_and_transcripts/S2A-001_1.wav
         source venv/bin/activate
         cd testing
         python duration.py -r ice-can

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -24,9 +24,9 @@ jobs:
 
     - name: Clone the private repository
       run: |
-        git clone https://x-access-token:${{ secrets.PAT }}@github.com/MontrealCorpusTools/polyglotdb-testing.git testing
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{ secrets.TESTING_SSH_KEY }}'
+        git clone ssh://git@github.com/MontrealCorpusTools/polyglotdb-testing.git testing
 
     - name: Set environment variable for private repo root
       run: echo "TEST_REPO_ROOT=$(pwd)/testing" >> $GITHUB_ENV

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@main
       with:
         repository: MontrealCorpusTools/polyglotdb-testing
-        ssh-key: ${{ secrets.TESTING_SSH_KEY }}
+        ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
         path: testing
         fetch-depth: 0
 

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -10,6 +10,7 @@ jobs:
 
     env:
       PGDB_HOME: ${{ github.workspace }}/pgdb_home  # Use workspace directory
+      TEST_REPO_ROOT: ${{ github.workspace }}/testing  # Use workspace directory
 
     steps:
     - name: Checkout main repository
@@ -23,14 +24,8 @@ jobs:
       with:
         repository: MontrealCorpusTools/polyglotdb-testing
         ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
-        path: testing
+        path: ${{ github.workspace }}/testing
         fetch-depth: 0
-
-    - name: Set environment variable for private repo root
-      run: |
-        echo "TEST_REPO_ROOT=$(pwd)/testing" >> $GITHUB_ENV
-        ls
-        ls $TEST_REPO_ROOT
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v4
@@ -66,6 +61,8 @@ jobs:
 
     - name: Run duration.py
       run: |
+        echo $TEST_REPO_ROOT
+        ls $TEST_REPO_ROOT
         source venv/bin/activate
         cd testing
         python duration.py -r ice-can


### PR DESCRIPTION
Update how the testing repository is cloned to not rely on access tokens that can expire, following https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions